### PR TITLE
feat: add/intel mpi example

### DIFF
--- a/example/hello-world-intel-mpi/README.md
+++ b/example/hello-world-intel-mpi/README.md
@@ -4,6 +4,7 @@ This example shows requesting using the intel MPI snippet, which means adding a 
 command to your code. An hpc-* flavored family is required (which is the default).
 
 ```bash
-snakemake --jobs 1 --executor googlebatch --googlebatch-region us-central1 --googlebatch-project llnl-flux --default-storage-provider s3 --default-storage-prefix s3://snakemake-testing-llnl --googlebatch-snippets intel-mpi
+GOOGLE_PROJECT=myproject
+snakemake --jobs 1 --executor googlebatch --googlebatch-region us-central1 --googlebatch-project ${GOOGLE_PROJECT} --default-storage-provider s3 --default-storage-prefix s3://my-snakemake-testing --googlebatch-snippets intel-mpi
 ```
 

--- a/example/hello-world-intel-mpi/README.md
+++ b/example/hello-world-intel-mpi/README.md
@@ -1,0 +1,9 @@
+# Hello World Intel MPI
+
+This example shows requesting using the intel MPI snippet, which means adding a custom setup and run
+command to your code. An hpc-* flavored family is required (which is the default).
+
+```bash
+snakemake --jobs 1 --executor googlebatch --googlebatch-region us-central1 --googlebatch-project llnl-flux --default-storage-provider s3 --default-storage-prefix s3://snakemake-testing-llnl --googlebatch-snippets intel-mpi
+```
+

--- a/example/hello-world-intel-mpi/Snakefile
+++ b/example/hello-world-intel-mpi/Snakefile
@@ -1,0 +1,57 @@
+# https://github.com/snakemake/snakemake/blob/main/tests/test_slurm_mpi/Snakefile
+# Note that in reality, the mpi, account, and partition resources should be specified
+# via --default-resources, in order to keep such infrastructure specific details out of the
+# workflow definition.
+
+
+localrules:
+    all,
+    clean,
+    copy,
+
+rule all:
+    input:
+        "pi.calc",
+
+rule clean:
+    shell:
+        "rm -f pi.calc"
+
+rule copy:
+    input:
+        local("pi_MPI.c"),
+    output:
+        "pi_MPI.c",
+    log:
+        "logs/copy.log",
+    resources:
+        mem_mb=0,
+    shell:
+        "cp {input} {output} &> {log}"
+
+rule compile:
+    input:
+        "pi_MPI.c",
+    output:
+        "pi_MPI",
+    log:
+        "logs/compile.log",
+    resources:
+        mem_mb=0,
+    shell:
+        "mpicc -o {output} {input} &> {log}"
+
+rule calc_pi:
+    input:
+        "pi_MPI",
+    output:
+        "pi.calc",
+    log:
+        "logs/calc_pi.log",
+    resources:
+        mem_mb=0,
+        tasks=1,
+        mpi="mpiexec",
+    shell:
+        "chmod +x {input};"
+        "{resources.mpi} -hostfile $BATCH_HOSTS_FILE -n {resources.tasks} {input} 10 > {output};"

--- a/example/hello-world-intel-mpi/pi_MPI.c
+++ b/example/hello-world-intel-mpi/pi_MPI.c
@@ -1,0 +1,66 @@
+#include <stdio.h>
+#include <math.h>
+#include "stdlib.h"
+#include "mpi.h"
+
+
+double f(double x){
+  return ( 4.0/(1.0 + x*x) );
+}
+
+
+int main(int argc,char *argv[])
+{
+
+  int myrank, size;
+
+  MPI_Init(&argc, &argv);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
+
+  long long int i, n;
+  double PI25DT = 3.141592653589793238462643;
+  double mypi, pi, h, mysum, x;
+  
+  
+
+  /* Argument handling from command line */
+  if( 2 == argc ){
+    n = atoll(argv[1]);
+  }else{
+    if( 0 == myrank ){
+      n = 10000000;
+      printf("Too many or no argument given; using n = %d instead.\n", n);
+    }
+  }
+  
+
+  MPI_Bcast(&n, 1, MPI_LONG_LONG_INT, 0, MPI_COMM_WORLD);
+
+  h = 1.0/( (double)n );
+  mysum = 0.0;
+  
+  for(i = myrank+1 ; i <= n ; i += size){
+    x = h*((double)i - 0.5);
+    mysum = mysum + f(x);
+  }
+  
+  mypi = h*mysum;
+
+  MPI_Reduce(&mypi, &pi, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+  
+  /* Output result if myrank==0 */
+  if( 0 == myrank ){
+    char* filename = argv[1];   
+    FILE *fp;
+    char buf[0x100];    
+    snprintf(buf, sizeof(buf), "%s", filename);
+    fp = fopen(buf, "w+");
+    fprintf(fp, "\nUsing %d processes and the value n = %d.\n",size,n);
+    fprintf(fp, "Calculated pi: %.16f, with error %.16f\n\n", pi, fabs(pi - PI25DT));
+    fclose(fp);    
+  }
+
+  MPI_Finalize();
+  return 0;
+}

--- a/snakemake_executor_plugin_googlebatch/snippets/intel-mpi/run.sh
+++ b/snakemake_executor_plugin_googlebatch/snippets/intel-mpi/run.sh
@@ -8,6 +8,6 @@ source /opt/intel/mpi/latest/env/vars.sh
 if [ $BATCH_TASK_INDEX = 0 ]; then
   ls
   which mpirun
-  echo "{% if resources.mpi %}{{ resources.mpi }}{% else %}mpiexec{% endif %} -hostfile $BATCH_HOSTS_FILE -n {{ settings.tasks }} -ppn {{ settings.tasks_per_node }} {{ command }}"
-  {% if resources.mpi %}{{ resources.mpi }}{% else %}mpiexec{% endif %} -hostfile $BATCH_HOSTS_FILE -n {{ settings.tasks }} -ppn {{ settings.tasks_per_node }} {{ command }}
+  echo "{{ command }}"
+  {{ command }}
 fi


### PR DESCRIPTION
This adds the intel mpi example. The example functionally works, but the actual command does not write the output to file (it is empty). I pinged @johanneskoester about this and likely it needs to be debugged (the workflow is also in core snakemake) but technically speaking the google batch portion of this is working as expected so I think we can PR here. My credits for this project are expiring early January (and I haven't used a ton) so we need to keep moving.
