### PR TITLE
feat: add support for Google Batch GPUs

### DIFF
--- a/docs/further.md
+++ b/docs/further.md
@@ -128,6 +128,12 @@ The following environment variables are available within any Google batch run:
 
  - `BATCH_TASK_INDEX`: The index of the workflow step (Google Batch calls a "task")
 
+### GPU
+
+The Google Batch executor uses the same designation for GPUs as core Snakemake. However, you should 
+[keep compatibility of machine type](https://cloud.google.com/compute/docs/gpus) with the GPU
+that you selected in mind. For example, if you select `gpu_nvidia=1` you will need an n1-* family machine type.
+
 ### Step Options
 
 The following options are allowed for batch steps. This predominantly includes most arguments.

--- a/example/hello-world-gpu/README.md
+++ b/example/hello-world-gpu/README.md
@@ -1,0 +1,7 @@
+# Hello World + GPU
+
+Here is an example that runs hello world, but asks for a GPU resource.
+
+```bash
+$ snakemake --jobs 1 --executor googlebatch --googlebatch-region us-central1 --googlebatch-machine-type n1-standard-8 --googlebatch-project llnl-flux --default-storage-provider s3 --default-storage-prefix s3://snakemake-testing-llnl
+```

--- a/example/hello-world-gpu/Snakefile
+++ b/example/hello-world-gpu/Snakefile
@@ -1,0 +1,21 @@
+# By convention, the first pseudorule should be called "all"
+# We're using the expand() function to create multiple targets
+rule all:
+	input:
+		expand(
+			"{greeting}/gpu-world.txt",
+			greeting = ['hello', 'hola'],
+		),
+
+# First real rule, this is using a wildcard called "greeting"
+rule multilingual_hello_world:
+	output:
+		"{greeting}/gpu-world.txt",
+	resources:
+		nvidia_gpu=1
+	shell:
+		"""
+		mkdir -p "{wildcards.greeting}"
+		sleep 5
+		echo "{wildcards.greeting}, World!" > {output}
+		"""

--- a/snakemake_executor_plugin_googlebatch/command.py
+++ b/snakemake_executor_plugin_googlebatch/command.py
@@ -34,7 +34,7 @@ install_snakemake = """
 echo "I am batch index ${BATCH_TASK_INDEX}"
 export PATH=/opt/conda/bin:${PATH}
 repo=https://raw.githubusercontent.com/snakemake/snakemake-executor-plugin-googlebatch
-path=add-preemtible/scripts/install-snek.sh
+path=main/scripts/install-snek.sh
 wget ${repo}/${path}
 chmod +x ./install-snek.sh
 workdir=$(pwd)


### PR DESCRIPTION
@johanneskoester this adds support for GPU (accelerators) and uses the default/standard Snakemake way to define them.

https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#gpu-resources

The easiest way for the user to mess up is choosing the wrong instance type, but when that happens the error from batch provide a clear link to the page where you match them up, so I think we should be good.