### PR TITLE
fix: ensure we install datrie

### DIFF
--- a/snakemake_executor_plugin_googlebatch/command.py
+++ b/snakemake_executor_plugin_googlebatch/command.py
@@ -44,6 +44,7 @@ chmod +x ./miniconda.sh
 bash ./miniconda.sh -b -u -p /opt/conda
 rm -rf ./miniconda.sh
 
+conda install datrie --yes
 which python
 /opt/conda/bin/python --version
 ./install-snek.sh https://github.com/snakemake/snakemake-storage-plugin-gcs


### PR DESCRIPTION
Problem: newer version of python (via conda) missing datrie (the wheel fails to build)
Solution: install datrie with conda

This should fix #36 