### PR TITLE
fix: batch job ID and label prior to submission

### DIFF
--- a/.github/workflows/ci_mocked_api.yaml
+++ b/.github/workflows/ci_mocked_api.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
 
 jobs:
   formatting:

--- a/.github/workflows/ci_mocked_api.yaml
+++ b/.github/workflows/ci_mocked_api.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
 
 jobs:
   formatting:

--- a/snakemake_executor_plugin_googlebatch/executor.py
+++ b/snakemake_executor_plugin_googlebatch/executor.py
@@ -56,7 +56,7 @@ class GoogleBatchExecutor(RemoteExecutor):
         """
         Derive default labels for the job (and add custom)
         """
-        labels = {"snakemake-job": job.name}
+        labels = {"snakemake-job": self.fix_job_name(job.name)}
         for contender in self.get_param(job, "labels").split(","):
             if not contender:
                 continue
@@ -93,7 +93,7 @@ class GoogleBatchExecutor(RemoteExecutor):
         Generate a random jobid
         """
         uid = str(uuid.uuid4())
-        return job.name.replace("_", "-") + "-" + uid[0:6]
+        return self.fix_job_name(job.name) + "-" + uid[0:6]
 
     def get_container(self, job, entrypoint=None, commands=None):
         """
@@ -179,6 +179,13 @@ class GoogleBatchExecutor(RemoteExecutor):
             settings=self.workflow.executor_settings,
             resources=job.resources,
         )
+
+    def fix_job_name(self, name):
+        """
+        Replace illegal symbols and fix the job name length to adhere to
+        the Google Batch API job ID and label naming restrictions
+        """
+        return name.replace("_", "-").replace(".", "")[:50]
 
     def run_job(self, job: JobExecutorInterface):
         """


### PR DESCRIPTION
This PR addresses the issues with job names submitted to Google Batch that are too long or have incorrect characters.

Closes #57 and #55. 