### PR TITLE
docs: add details in gpu selection

### DIFF
--- a/docs/further.md
+++ b/docs/further.md
@@ -109,6 +109,11 @@ The Google Batch executor uses the same designation for GPUs as core Snakemake. 
 [keep compatibility of machine type](https://cloud.google.com/compute/docs/gpus) with the GPU
 that you selected in mind. For example, if you select `gpu_nvidia=1` you will need an n1-* family machine type.
 
+On a n1-* family machine type, gpu_nvidia=1 will trigger a "nvidia-tesla-t4" gpu by default.
+
+It's possible to change the gpu type directly using the a machine compatible label:
+e.g. nvidia_gpu='nvidia-tesla-v100'
+
 ### Step Options
 
 The following options are allowed for batch steps. This predominantly includes most arguments.

--- a/docs/further.md
+++ b/docs/further.md
@@ -111,7 +111,7 @@ that you selected in mind. For example, if you select `gpu_nvidia=1` you will ne
 
 On a n1-* family machine type, gpu_nvidia=1 will trigger a "nvidia-tesla-t4" gpu by default.
 
-It's possible to change the gpu type directly using the a machine compatible label:
+It's possible to change the gpu type directly using a machine-compatible label:
 e.g. nvidia_gpu='nvidia-tesla-v100'
 
 ### Step Options

--- a/docs/further.md
+++ b/docs/further.md
@@ -107,9 +107,9 @@ The following environment variables are available within any Google batch run:
 
 The Google Batch executor uses the same designation for GPUs as core Snakemake. However, you should 
 [keep compatibility of machine type](https://cloud.google.com/compute/docs/gpus) with the GPU
-that you selected in mind. For example, if you select `gpu_nvidia=1` you will need an n1-* family machine type.
+that you selected in mind. For example, if you select `nvidia_gpu=1` you will need an n1-* family machine type.
 
-On a n1-* family machine type, gpu_nvidia=1 will trigger a "nvidia-tesla-t4" gpu by default.
+On a n1-* family machine type, nvidia_gpu=1 will trigger a "nvidia-tesla-t4" gpu by default.
 
 It's possible to change the gpu type directly using a machine-compatible label:
 e.g. nvidia_gpu='nvidia-tesla-v100'


### PR DESCRIPTION
Added an example of GPU labelling in the documentation to make it more explicit. (It can help snakemake newcomers) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated GPU configuration guidance: use the machine-specific label nvidia_gpu (e.g., nvidia_gpu=1).
  * Noted that on n1-* machines nvidia_gpu=1 defaults to an NVIDIA Tesla T4.
  * Added guidance and examples for selecting a different GPU by specifying a machine-compatible GPU type (for example, nvidia-tesla-v100).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->